### PR TITLE
ENG-9377-22.1 Refresh xebialabs/tiny-tools image version 

### DIFF
--- a/deploy-operator-aws-eks/digitalai-deploy/kubernetes/daideploy_cr.yaml
+++ b/deploy-operator-aws-eks/digitalai-deploy/kubernetes/daideploy_cr.yaml
@@ -13,6 +13,10 @@ spec:
   ServerImageRepository: xebialabsunsupported/xl-deploy
   WorkerImageRepository: xebialabsunsupported/deploy-task-engine
   ImageTag: "22.1.0-315.452"
+  ## xebialabs/tiny-tools image version
+  ## Ref: https://hub.docker.com/r/xebialabs/tiny-tools/tags
+  TinyToolsImageRepository: "xebialabs/tiny-tools"
+  TinyToolsImageTag: "22.2.0"
   # Secrets must be manually created in the namespace
   # ImagePullSecret: xlDeploy
   K8sSetup:

--- a/deploy-operator-azure-aks/digitalai-deploy/kubernetes/daideploy_cr.yaml
+++ b/deploy-operator-azure-aks/digitalai-deploy/kubernetes/daideploy_cr.yaml
@@ -13,6 +13,10 @@ spec:
   ServerImageRepository: xebialabsunsupported/xl-deploy
   WorkerImageRepository: xebialabsunsupported/deploy-task-engine
   ImageTag: "22.1.0-315.452"
+  ## xebialabs/tiny-tools image version
+  ## Ref: https://hub.docker.com/r/xebialabs/tiny-tools/tags
+  TinyToolsImageRepository: "xebialabs/tiny-tools"
+  TinyToolsImageTag: "22.2.0"
   # Secrets must be manually created in the namespace
   # ImagePullSecret: xlDeploy
   K8sSetup:

--- a/deploy-operator-gcp-gke/digitalai-deploy/kubernetes/daideploy_cr.yaml
+++ b/deploy-operator-gcp-gke/digitalai-deploy/kubernetes/daideploy_cr.yaml
@@ -13,6 +13,10 @@ spec:
   ServerImageRepository: xebialabsunsupported/xl-deploy
   WorkerImageRepository: xebialabsunsupported/deploy-task-engine
   ImageTag: "22.1.0-315.452"
+  ## xebialabs/tiny-tools image version
+  ## Ref: https://hub.docker.com/r/xebialabs/tiny-tools/tags
+  TinyToolsImageRepository: "xebialabs/tiny-tools"
+  TinyToolsImageTag: "22.2.0"
   # Secrets must be manually created in the namespace
   # ImagePullSecret: xlDeploy
   K8sSetup:

--- a/deploy-operator-onprem/digitalai-deploy/kubernetes/daideploy_cr.yaml
+++ b/deploy-operator-onprem/digitalai-deploy/kubernetes/daideploy_cr.yaml
@@ -13,6 +13,10 @@ spec:
   ServerImageRepository: xebialabsunsupported/xl-deploy
   WorkerImageRepository: xebialabsunsupported/deploy-task-engine
   ImageTag: "22.1.0-315.452"
+  ## xebialabs/tiny-tools image version
+  ## Ref: https://hub.docker.com/r/xebialabs/tiny-tools/tags
+  TinyToolsImageRepository: "xebialabs/tiny-tools"
+  TinyToolsImageTag: "22.2.0"
   # Secrets must be manually created in the namespace
   # ImagePullSecret: xlDeploy
   K8sSetup:

--- a/deploy-operator-openshift/digitalai-deploy/kubernetes/daideploy_cr.yaml
+++ b/deploy-operator-openshift/digitalai-deploy/kubernetes/daideploy_cr.yaml
@@ -12,7 +12,15 @@ spec:
   ImagePullPolicy: Always
   ServerImageRepository: xebialabsunsupported/xl-deploy
   WorkerImageRepository: xebialabsunsupported/deploy-task-engine
+<<<<<<< HEAD
   ImageTag: "22.1.0-315.452"
+=======
+  ImageTag: "22.2.0-315.113"
+  ## xebialabs/tiny-tools image version
+  ## Ref: https://hub.docker.com/r/xebialabs/tiny-tools/tags
+  TinyToolsImageRepository: "xebialabs/tiny-tools"
+  TinyToolsImageTag: "22.2.0"
+>>>>>>> d101a3a... ENG-9236 Refresh xebialabs/tiny-tools image version (#40)
   # Secrets must be manually created in the namespace
   # ImagePullSecret: xlDeploy
   KeystorePassphrase: <Provide store pass for the keystore>

--- a/deploy-operator-openshift/digitalai-deploy/kubernetes/daideploy_cr.yaml
+++ b/deploy-operator-openshift/digitalai-deploy/kubernetes/daideploy_cr.yaml
@@ -12,15 +12,11 @@ spec:
   ImagePullPolicy: Always
   ServerImageRepository: xebialabsunsupported/xl-deploy
   WorkerImageRepository: xebialabsunsupported/deploy-task-engine
-<<<<<<< HEAD
   ImageTag: "22.1.0-315.452"
-=======
-  ImageTag: "22.2.0-315.113"
   ## xebialabs/tiny-tools image version
   ## Ref: https://hub.docker.com/r/xebialabs/tiny-tools/tags
   TinyToolsImageRepository: "xebialabs/tiny-tools"
   TinyToolsImageTag: "22.2.0"
->>>>>>> d101a3a... ENG-9236 Refresh xebialabs/tiny-tools image version (#40)
   # Secrets must be manually created in the namespace
   # ImagePullSecret: xlDeploy
   KeystorePassphrase: <Provide store pass for the keystore>


### PR DESCRIPTION
* ENG-9236-oc Refresh xebialabs/tiny-tools image version

* ENG-9236 updated the tiny-tools version to 22.2.0

* ENG-9236 updated the tiny-tools repository